### PR TITLE
fix check_who_win test in lesson_04/homework/tic_tac_toe_test.exs

### DIFF
--- a/lesson_04/homework/tic_tac_toe_test.exs
+++ b/lesson_04/homework/tic_tac_toe_test.exs
@@ -34,7 +34,7 @@ defmodule Test do
     assert {:win, :x} == check_who_win({{:f, :o, :f}, {:o, :f, :f}, {:x, :x, :x}})
 
     assert {:win, :o} == check_who_win({{:o, :x, :f}, {:o, :f, :x}, {:o, :f, :f}})
-    assert {:win, :x} == check_who_win({{:f, :x, :o}, {:p, :x, :f}, {:f, :x, :f}})
+    assert {:win, :x} == check_who_win({{:f, :x, :o}, {:o, :x, :f}, {:f, :x, :f}})
     assert {:win, :o} == check_who_win({{:f, :x, :o}, {:f, :x, :o}, {:f, :f, :o}})
 
     assert {:win, :x} == check_who_win({{:x, :f, :o}, {:o, :x, :f}, {:f, :f, :x}})


### PR DESCRIPTION
Испавление опечатки в тесте домашки tic-tac-toe :p -> :o